### PR TITLE
cleanup 03training notebooks

### DIFF
--- a/03_training/pytorch/cv_hpo_pytorch_pipe.ipynb
+++ b/03_training/pytorch/cv_hpo_pytorch_pipe.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Computer Vision (CV) On SageMaker - Tensorflow\n",
+    "# Computer Vision (CV) On SageMaker - Pytorch\n",
     "\n",
     "1. [Introduction](#Introduction)\n",
     "2. [Prerequisites](#Prerequisites)\n",
@@ -28,7 +28,7 @@
     "# Introduction\n",
     "This lab is focused on SageMaker Training for CV. We'll show an example for the performant Pipe Mode data ingestion, HyperParameter Optimization, as well as experiment tracking. In the future labs we'll show how experiment tracking can be automated through SageMaker Pipeline's native integration. The model used for this notebook is a simple deep CNN that is based on the [Sagemaker PyTorch examples](https://sagemaker-examples.readthedocs.io/en/latest/aws_sagemaker_studio/frameworks/pytorch_cnn_cifar10/pytorch_cnn_cifar10.html). \n",
     "\n",
-    "** Note: This Notebook was tested on Data Science Kernel for SageMaker Studio**"
+    "** Note: This Notebook was tested on Python 3 (PyTorch 1.8 Python 3.6) kernal for SageMaker**"
    ]
   },
   {
@@ -39,7 +39,7 @@
     "\n",
     "To run this notebook, you can simply execute each cell in order. To understand what's happening, you'll need:\n",
     "\n",
-    "- Access to the SageMaker default S3 bucket. All the files related to this lab will be stored under the \"cv_keras_cifar10\" prefix of the bucket.\n",
+    "- Access to the SageMaker default S3 bucket. All the files related to this lab will be stored under the \"cv_python_cifar10\" prefix of the bucket.\n",
     "- Familiarity with Python and numpy\n",
     "- Basic familiarity with AWS S3.\n",
     "- Basic understanding of AWS Sagemaker.\n",
@@ -138,7 +138,7 @@
     "## Dataset\n",
     "The [CIFAR-10 dataset](https://www.cs.toronto.edu/~kriz/cifar.html) is one of the most popular machine learning datasets. It consists of 60,000 32x32 images belonging to 10 different classes (6,000 images per class). Here are the classes in the dataset, as well as 10 random images from each:\n",
     "\n",
-    "![cifar10](statics/CIFAR-10.png)\n",
+    "![cifar10](../statics/CIFAR-10.png)\n",
     "\n",
     "In this tutorial, we will train a deep CNN to recognize these images.\n",
     "\n",
@@ -279,14 +279,6 @@
    "metadata": {},
    "source": [
     "### Build A Training Estimator"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We are going to train the model with Pipe Mode input. SageMaker Pipe Mode is a mechanism for providing S3 data to a training job via Linux fifos. Training programs can read from the fifo and get high-throughput data transfer from S3, without managing the S3 access in the program itself.\n",
-    "Pipe Mode is covered in more detail in the SageMaker [documentation](https://docs.aws.amazon.com/sagemaker/latest/dg/your-algorithms-training-algo-running-container.html#your-algorithms-training-algo-running-container-trainingdata)."
    ]
   },
   {
@@ -515,7 +507,7 @@
    "source": [
     "The **```fit```** method will create a training job on **ml.c5.xlarge** instance.\n",
     "\n",
-    "These instances will write checkpoints and logs to the S3 bucket we've set up earlier. If you don't have this bucket yet, **```sagemaker_session```** will create it for you. These checkpoints and logs can be used for restoring the training job, and to analyze training job metrics using TensorBoard. "
+    "These instances will write checkpoints and logs to the S3 bucket we've set up earlier. If you don't have this bucket yet, **```sagemaker_session```** will create it for you. These checkpoints and logs can be used for restoring the training job, and to analyze training job metrics. "
    ]
   },
   {
@@ -528,7 +520,7 @@
     "\n",
     "Since we specified an Experiment trial, you can also view the \"SageMaker resources\" icon  in SageMaker Studio, select \"Experiments and trials\", open the trial, and eplorer trial details to view metric charts, summary stats, and hyperparameters associated with the experiment.\n",
     "\n",
-    "![Experiment UI](statics/Experiments.png)"
+    "![Experiment UI](../statics/Experiments.png)"
    ]
   },
   {
@@ -546,7 +538,7 @@
    "source": [
     "### Configure HPO Job\n",
     "Next, the tuning job with the following configurations need to be specified:\n",
-    "- hyperparameters that SageMaker Automatic Model Tuning will tune: `learning-rate`, `batch-size` and `optimizer`;\n",
+    "- hyperparameters that SageMaker Automatic Model Tuning will tune: `learning-rate` and `batch-size`;\n",
     "- maximum number of training jobs it will run to optimize the objective metric: `6`\n",
     "- number of parallel training jobs that will run in the tuning job: `2`\n",
     "- objective metric that Automatic Model Tuning will use: `validation:accuracy`\n",
@@ -639,7 +631,7 @@
     "This process is can be eliminated when expecuted from a [SageMaker Pipeline Tuning Step](https://sagemaker.readthedocs.io/en/stable/workflows/pipelines/sagemaker.workflow.pipelines.html#sagemaker.workflow.steps.TuningStep)\n",
     "\n",
     "After running the code below, you should see something like this in your studio environment:\n",
-    "![HPO Experiments](statics/HPO_experiments.png)\n"
+    "![HPO Experiments](../statics/HPO_experiments.png)\n"
    ]
   },
   {

--- a/03_training/tensorflow/cv_hpo_keras_pipe.ipynb
+++ b/03_training/tensorflow/cv_hpo_keras_pipe.ipynb
@@ -107,7 +107,7 @@
     "## Dataset\n",
     "The [CIFAR-10 dataset](https://www.cs.toronto.edu/~kriz/cifar.html) is one of the most popular machine learning datasets. It consists of 60,000 32x32 images belonging to 10 different classes (6,000 images per class). Here are the classes in the dataset, as well as 10 random images from each:\n",
     "\n",
-    "![cifar10](statics/CIFAR-10.png)\n",
+    "![cifar10](../statics/CIFAR-10.png)\n",
     "\n",
     "In this tutorial, we will train a deep CNN to recognize these images.\n",
     "\n",
@@ -343,7 +343,7 @@
     "\n",
     "Since we specified an Experiment trial, you can also view the \"SageMaker resources\" icon  in SageMaker Studio, select \"Experiments and trials\", open the trial, and eplorer trial details to view metric charts, summary stats, and hyperparameters associated with the experiment.\n",
     "\n",
-    "![Experiment UI](statics/Experiments.png)"
+    "![Experiment UI](../statics/Experiments.png)"
    ]
   },
   {
@@ -437,7 +437,7 @@
     "This process is can be eliminated when expecuted from a [SageMaker Pipeline Tuning Step](https://sagemaker.readthedocs.io/en/stable/workflows/pipelines/sagemaker.workflow.pipelines.html#sagemaker.workflow.steps.TuningStep)\n",
     "\n",
     "After running the code below, you should see something like this in your studio environment:\n",
-    "![HPO Experiments](statics/HPO_experiments.png)\n"
+    "![HPO Experiments](../statics/HPO_experiments.png)\n"
    ]
   },
   {


### PR DESCRIPTION
cleanup 03training notebooks, fixed images after restructure, removed tensorflow references in pytorch notebook


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
